### PR TITLE
Jump to 3-rd version of handlebars

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "node_modules/.bin/mocha"
   },
   "dependencies": {
-    "handlebars": "^2.0.0",
+    "handlebars": "^3.0.0",
     "umd-wrapper": "~0.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
It needs to use 3-rd version of handlebars because 2-nd can't handle depths correctly. E.g., `{{#each items}}{{../field1}}{{/each}}`.
